### PR TITLE
fix missing interview fields

### DIFF
--- a/app/models/uploaded_interview.rb
+++ b/app/models/uploaded_interview.rb
@@ -16,6 +16,7 @@ class UploadedInterview
       save_interviewee if interviewee.nil?
       save_interviewer if interviewer.nil?
       validate_zip_file && save_interview_responses
+      interview.save
     end
   end
 


### PR DESCRIPTION
Save interview (again) after reading interviewer/interviewee. Fixes server error on ~/interviews/1 after uploading an interview from the android app